### PR TITLE
ClosestPointsBetweenTwoShapesDto constructor sets shape1 and shape2

### DIFF
--- a/lib/api/inputs/occ-inputs.ts
+++ b/lib/api/inputs/occ-inputs.ts
@@ -134,14 +134,23 @@ export namespace OCCT {
         points: Base.Point3[];
     }
     export class ClosestPointsBetweenTwoShapesDto<T> extends ShapesDto<T> {
+        constructor(shapes?: T[]) {
+            super(shapes);
+            if(shapes.length > 0) {
+                this.shape1 = shapes[0];
+            }
+            if(shapes.length > 1) {
+                this.shape2 = shapes[1];
+            }
+        }
         /**
          * The OCCT shapes
-         * @default undefined
+         * @default shapes[0]
          */
         shape1?: T;
         /**
         * The OCCT shapes
-        * @default undefined
+        * @default shapes[1]
         */
         shape2?: T;
     }

--- a/lib/api/inputs/occ-inputs.ts
+++ b/lib/api/inputs/occ-inputs.ts
@@ -134,23 +134,17 @@ export namespace OCCT {
         points: Base.Point3[];
     }
     export class ClosestPointsBetweenTwoShapesDto<T> extends ShapesDto<T> {
-        constructor(shapes?: T[]) {
-            super(shapes);
-            if(shapes.length > 0) {
-                this.shape1 = shapes[0];
-            }
-            if(shapes.length > 1) {
-                this.shape2 = shapes[1];
-            }
+        constructor(shape1?: T, shape2?: T) {
+            super([shape1, shape2]);
         }
         /**
          * The OCCT shapes
-         * @default shapes[0]
+         * @default undefined
          */
         shape1?: T;
         /**
         * The OCCT shapes
-        * @default shapes[1]
+        * @default undefined
         */
         shape2?: T;
     }


### PR DESCRIPTION
Added a constructor to the derived ClosestPointsBetweenTwoShapesDto class so that the needed shape1 and shape2 are set, and the shapes list is not redundant.
I'm not sure this is the best way, it may be better to not extend the ShapesDto and instead have a specifict constructor like:
```constructor(shape1: TopoDS_Shape, shape2, TopoDS_Shape)```
which would be my preference, but would break any existing usage.