### PR TITLE
Fix package-lock?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "bitbybit-occt",
-    "version": "0.10.10",
+    "name": "@bitbybit-dev/occt",
+    "version": "0.11.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "bitbybit-occt",
-            "version": "0.10.10",
+            "name": "@bitbybit-dev/occt",
+            "version": "0.11.13",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.16.0",


### PR DESCRIPTION
package-lock updated when I did npm install. Seems like wrong info to the old repo, not sure why it seems like it self-references though.