### PR TITLE
Make OpenCascadeInstance public readonly so devs can use BREP

### DIFF
--- a/lib/occ-helper.ts
+++ b/lib/occ-helper.ts
@@ -29,7 +29,7 @@ export class OccHelper {
     constructor(
         public readonly vecHelper: VectorHelperService,
         public readonly shapesHelperService: ShapesHelperService,
-        private readonly occ: OpenCascadeInstance) {
+        public readonly occ: OpenCascadeInstance) {
     }
 
     getCornerPointsOfEdgesForShape(inputs: Inputs.OCCT.ShapeDto<TopoDS_Shape>): Inputs.Base.Point3[] {


### PR DESCRIPTION
Selfish motivations really.
I like to use occ elsewhere to have access to the BREP functions. This change will allow devs who want to create their own functions using underlying opencascade once the magic to type everything has been done. It is still readonly so devs shouldn't break.change current functionality.