### PR TITLE
Edit test commands to run on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
         "build-occt": "node generate-prod-build-yaml.js && cd bitbybit-dev-occt && docker run --rm -it -v \"$(pwd):/src\" -u \"$(id -u):$(id -g)\" donalffons/opencascade.js bitbybit-dev-occt.yml && cd ../",
         "build-occt-multithreaded": "node generate-prod-build-yaml-multithreaded.js && cd bitbybit-dev-occt-multithreaded && docker run --rm -it -v \"$(pwd):/src\" -u \"$(id -u):$(id -g)\" donalffons/opencascade.js:multi-threaded bitbybit-dev-occt.yml && cd ../",
         "docs": "./node_modules/.bin/sass ts-doc-theme/assets/css/main.sass ts-doc-theme/assets/css/main.css && node_modules/.bin/typedoc --out ts-api-docs/ lib/api --theme ./ts-doc-theme --excludePrivate --tsconfig lib/api/tsconfig.bbb.json --media assets/images/blockly-block-images/ && node mvdocpictures",
-        "test": "NODE_OPTIONS=--experimental-specifier-resolution=node jest --watchAll=true",
-        "test-c": "NODE_OPTIONS=--experimental-specifier-resolution=node jest --coverage --watchAll=false",
-        "test-c-l": "NODE_OPTIONS=--experimental-specifier-resolution=node jest --coverage --watchAll=true",
+        "test": "set NODE_OPTIONS=--experimental-specifier-resolution=node && jest --watchAll=true",
+        "test-c": "set NODE_OPTIONS=--experimental-specifier-resolution=node && jest --coverage --watchAll=false",
+        "test-c-l": "set NODE_OPTIONS=--experimental-specifier-resolution=node && jest --coverage --watchAll=true",
         "lint": "eslint . --ext .ts",
         "lint-fix": "eslint . --ext .ts --fix"
     },


### PR DESCRIPTION
The changes allow the test commands to run on windows (my laptop with win11 anyway). Got the solution from here in case you prefer a different method, but this seemed the best with no extra packages. Please can you check on mac.

https://stackoverflow.com/questions/53948521/node-options-is-not-recognized-as-an-internal-or-external-command
