### PR TITLE
Develop

### DIFF
--- a/lib/api/inputs/occ-inputs.ts
+++ b/lib/api/inputs/occ-inputs.ts
@@ -144,7 +144,7 @@ export namespace OCCT {
          * The OCCT shapes
          * @default undefined
          */
-        shapes?: T[];
+        shapes: T[];
     }
     export class PointDto {
         constructor(point?: Base.Point3) {
@@ -154,7 +154,7 @@ export namespace OCCT {
          * The point
          * @default [0, 0, 0]
          */
-        point?: Base.Point3 = [0, 0, 0];
+        point: Base.Point3 = [0, 0, 0];
     }
     export class PointsDto {
         constructor(points?: Base.Point3[]) {
@@ -164,7 +164,7 @@ export namespace OCCT {
          * The point
          * @default undefined
          */
-        points?: Base.Point3[];
+        points: Base.Point3[];
     }
     export class ConstraintTanLinesFromPtToCircleDto<T> {
         constructor(circle?: T, point?: Base.Point3) {
@@ -175,7 +175,7 @@ export namespace OCCT {
          * The circle for tangent points
          * @default undefined
          */
-        circle?: T;
+        circle: T;
         /**
          * The point from which to find the lines
          * @default undefined
@@ -212,7 +212,7 @@ export namespace OCCT {
          * The circle for tangent points
          * @default undefined
          */
-        circle?: T;
+        circle: T;
         /**
          * The point from which to find the lines
          * @default undefined
@@ -252,12 +252,12 @@ export namespace OCCT {
          * The first circle for tangential lines
          * @default undefined
          */
-        circle1?: T;
+        circle1: T;
         /**
          * The second circle for tangential lines
          * @default undefined
          */
-        circle2?: T;
+        circle2: T;
         /**
          * tolerance
          * @default 1e-7
@@ -396,12 +396,12 @@ export namespace OCCT {
          * First OCCT shape
          * @default undefined
          */
-        shape1?: T;
+        shape1: T;
         /**
         * Second OCCT shape
         * @default undefined
         */
-        shape2?: T;
+        shape2: T;
     }
     export class FaceFromSurfaceAndWireDto<T, U> {
         constructor(surface?: T, wire?: U, inside?: boolean) {
@@ -413,12 +413,12 @@ export namespace OCCT {
          * Surface from which to create a face
          * @default undefined
          */
-        surface?: T;
+        surface: T;
         /**
          * Wire that represents a boundary on the surface to delimit the face
          * @default undefined
          */
-        wire?: U;
+        wire: U;
         /**
          * Indicates wether face should be created inside or outside the wire
          * @default true
@@ -614,7 +614,7 @@ export namespace OCCT {
          * Brep OpenCascade geometry
          * @default undefined
          */
-        shapes?: T[];
+        shapes: T[];
         /**
          * Face opacity value between 0 and 1
          * @default 1
@@ -748,7 +748,7 @@ export namespace OCCT {
          * Brep OpenCascade geometry
          * @default undefined
          */
-        shape?: T;
+        shape: T;
         /**
          * Number of points that will be added on U direction
          * @default 10
@@ -821,7 +821,7 @@ export namespace OCCT {
          * Brep OpenCascade geometry
          * @default undefined
          */
-        shape?: T;
+        shape: T;
         /**
          * Number of subdivisions on U direction
          * @default 10
@@ -952,7 +952,7 @@ export namespace OCCT {
          * Brep OpenCascade geometry
          * @default undefined
          */
-        shape?: T;
+        shape: T;
         /**
          * Linear subdivision direction true - U, false - V
          * @default true
@@ -1004,7 +1004,7 @@ export namespace OCCT {
          * Brep OpenCascade geometry
          * @default undefined
          */
-        shape?: T;
+        shape: T;
         /**
          * Param on U direction 0 to 1
          * @default 0.5
@@ -1034,7 +1034,7 @@ export namespace OCCT {
          * Brep OpenCascade geometry
          * @default undefined
          */
-        shape?: T;
+        shape: T;
         /**
          * Params uv
          * @default [[0.5, 0.5]]

--- a/lib/api/inputs/occ-inputs.ts
+++ b/lib/api/inputs/occ-inputs.ts
@@ -167,9 +167,12 @@ export namespace OCCT {
         points: Base.Point3[];
     }
     export class ConstraintTanLinesFromPtToCircleDto<T> {
-        constructor(circle?: T, point?: Base.Point3) {
+        constructor(circle?: T, point?: Base.Point3, tolerance?: number, positionResult?: positionResultEnum, circleRemainder?: circleInclusionEnum) {
             if (circle !== undefined) { this.circle = circle; }
             if (point !== undefined) { this.point = point; }
+            if (tolerance !== undefined) { this.tolerance = tolerance; }
+            if (positionResult !== undefined) { this.positionResult = positionResult; }
+            if (circleRemainder !== undefined) { this.circleRemainder = circleRemainder; }
         }
         /**
          * The circle for tangent points
@@ -202,11 +205,13 @@ export namespace OCCT {
         circleRemainder: circleInclusionEnum = circleInclusionEnum.none;
     }
     export class ConstraintTanLinesFromTwoPtsToCircleDto<T> {
-        constructor(circle?: T, point1?: Base.Point3, point2?: Base.Point3) {
+        constructor(circle?: T, point1?: Base.Point3, point2?: Base.Point3, tolerance?: number, positionResult?: positionResultEnum, circleRemainder?: circleInclusionEnum) {
             if (circle !== undefined) { this.circle = circle; }
             if (point1 !== undefined) { this.point1 = point1; }
             if (point2 !== undefined) { this.point1 = point2; }
-
+            if (tolerance !== undefined) { this.tolerance = tolerance; }
+            if (positionResult !== undefined) { this.positionResult = positionResult; }
+            if (circleRemainder !== undefined) { this.circleRemainder = circleRemainder; }
         }
         /**
          * The circle for tangent points
@@ -244,9 +249,12 @@ export namespace OCCT {
         circleRemainder: circleInclusionEnum = circleInclusionEnum.none;
     }
     export class ConstraintTanLinesOnTwoCirclesDto<T> {
-        constructor(circle1?: T, circle2?: T) {
+        constructor(circle1?: T, circle2?: T, tolerance?: number, positionResult?: positionResultEnum, circleRemainders?: twoCircleInclusionEnum) {
             if (circle1 !== undefined) { this.circle1 = circle1; }
             if (circle2 !== undefined) { this.circle2 = circle2; }
+            if (tolerance !== undefined) { this.tolerance = tolerance; }
+            if (positionResult !== undefined) { this.positionResult = positionResult; }
+            if (circleRemainders !== undefined) { this.circleRemainders = circleRemainders; }
         }
         /**
          * The first circle for tangential lines
@@ -277,6 +285,75 @@ export namespace OCCT {
          * @default none
          */
         circleRemainders: twoCircleInclusionEnum = twoCircleInclusionEnum.none;
+    }
+
+    export class ConstraintTanCirclesOnTwoCirclesDto<T> {
+        constructor(circle1?: T, circle2?: T, tolerance?: number, radius?: number) {
+            if (circle1 !== undefined) { this.circle1 = circle1; }
+            if (circle2 !== undefined) { this.circle2 = circle2; }
+            if (tolerance !== undefined) { this.tolerance = tolerance; }
+            if (radius !== undefined) { this.radius = radius; }
+        }
+        /**
+         * The first circle for tangential lines
+         * @default undefined
+         */
+        circle1: T;
+        /**
+         * The second circle for tangential lines
+         * @default undefined
+         */
+        circle2: T;
+        /**
+         * tolerance
+         * @default 1e-7
+         * @minimum 0
+         * @maximum Infinity
+         * @step 0.00001
+         */
+        tolerance = 1e-7;
+        /**
+         * Radius of the circles being constructed
+         * @default 0.3
+         * @minimum 0
+         * @maximum Infinity
+         * @step 0.1
+         */
+        radius = 0.3;
+    }
+    export class ConstraintTanCirclesOnCircleAndPntDto<T> {
+        constructor(circle?: T, point?: Base.Point3, tolerance?: number, radius?: number) {
+            if (circle !== undefined) { this.circle = circle; }
+            if (point !== undefined) { this.point = point; }
+            if (tolerance !== undefined) { this.tolerance = tolerance; }
+            if (radius !== undefined) { this.radius = radius; }
+        }
+        /**
+         * The first circle for tangential lines
+         * @default undefined
+         */
+        circle: T;
+        /**
+         * The second circle for tangential lines
+         * @default undefined
+         */
+        point: Base.Point3;
+        /**
+         * tolerance
+         * @default 1e-7
+         * @minimum 0
+         * @maximum Infinity
+         * @step 0.00001
+         */
+        tolerance = 1e-7;
+        /**
+         * Radius of the circles being constructed
+         * @default 0.3
+         * @minimum 0
+         * @maximum Infinity
+         * @step 0.1
+         */
+        radius = 0.3;
     }
     export class CurveAndSurfaceDto<T, U>{
         constructor(curve?: T, surface?: U) {

--- a/lib/occ-helper.ts
+++ b/lib/occ-helper.ts
@@ -2666,6 +2666,7 @@ export class OccHelper {
         const shp = this.getActualTypeOfShape(s);
         s.delete();
         transformation.delete();
+        transf.delete();
         gpVec.delete();
         return shp;
     }
@@ -2706,20 +2707,22 @@ export class OccHelper {
             rotated = inputs.shape;
         } else {
             const transformation = new this.occ.gp_Trsf_1();
-            const pt1 = new this.occ.gp_Pnt_3(0, 0, 0);
             const gpVec = new this.occ.gp_Vec_4(inputs.axis[0], inputs.axis[1], inputs.axis[2]);
-            const dir = new this.occ.gp_Dir_2(gpVec);
+            const dir = new this.occ.gp_Dir_4(inputs.axis[0], inputs.axis[1], inputs.axis[2]);
+            const pt1 = new this.occ.gp_Pnt_3(0, 0, 0);
             const ax = new this.occ.gp_Ax1_2(pt1, dir);
-            transformation.SetRotation_1(ax, inputs.angle * 0.0174533);
-            const rotation = new this.occ.TopLoc_Location_2(transformation);
-            rotated = (inputs.shape as TopoDS_Shape).Moved(rotation, false);
-
-            transformation.delete();
-            pt1.delete();
+            transformation.SetRotation_1(ax , this.vecHelper.degToRad(inputs.angle));
+            const transf = new this.occ.BRepBuilderAPI_Transform_2(inputs.shape, transformation, true);
+            const s = transf.Shape();
+            const shp = this.getActualTypeOfShape(s);
+            s.delete();
             gpVec.delete();
             dir.delete();
+            pt1.delete();
             ax.delete();
-            rotation.delete();
+            transf.delete();
+            transformation.delete();
+            return shp;
         }
         const actualShape = this.getActualTypeOfShape(rotated);
         if (inputs.angle !== 0) {

--- a/lib/services/shapes/edge.ts
+++ b/lib/services/shapes/edge.ts
@@ -412,4 +412,12 @@ export class OCCTEdge {
     constraintTanLinesOnTwoCircles(inputs: Inputs.OCCT.ConstraintTanLinesOnTwoCirclesDto<TopoDS_Edge>): TopoDS_Shape[] {
         return this.och.constraintTanLinesOnTwoCircles(inputs);
     }
+
+    constraintTanCirclesOnTwoCircles(inputs: Inputs.OCCT.ConstraintTanCirclesOnTwoCirclesDto<TopoDS_Edge>): TopoDS_Shape[] {
+        return this.och.constraintTanCirclesOnTwoCircles(inputs);
+    }
+
+    constraintTanCirclesOnCircleAndPnt(inputs: Inputs.OCCT.ConstraintTanCirclesOnCircleAndPntDto<TopoDS_Edge>): TopoDS_Shape[] {
+        return this.och.constraintTanCirclesOnCircleAndPnt(inputs);
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.15.6",
+    "version": "0.15.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/occt",
-            "version": "0.15.6",
+            "version": "0.15.7",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.15.6",
+    "version": "0.15.7",
     "description": "Bit By Bit Developers CAD algorithms using OpenCascade Technology kernel. Run in Node and in Browser.",
     "main": "index.js",
     "repository": {


### PR DESCRIPTION
- Removed optionality from shape properties in the input DTO classes.
- **bitbybit.occt.shapes.edge.constraintTanCirclesOnTwoCircles** - Finds all of the circles that are tangential to two circles. Solution can contain one or more edges.
- **bitbybit.occt.shapes.edge.constraintTanCirclesOnCircleAndPnt** - Finds all of the circles that are tangential to a circle and a single point. Solution can contain one or more edges.
- **bitbybit.occt.transforms.rotate** - implementation changed to use better OCCT transformation approach. Previous rotation method had strange side effects for UV coordinates of faces. That caused problems in rendering.
