### PR TITLE
Develop

### DIFF
--- a/lib/api/inputs/occ-inputs.ts
+++ b/lib/api/inputs/occ-inputs.ts
@@ -4102,10 +4102,11 @@ export namespace OCCT {
         adjustYtoZ = false;
     }
     export class SaveStepDto<T> {
-        constructor(shape?: T, fileName?: string, adjustYtoZ?: boolean) {
+        constructor(shape?: T, fileName?: string, adjustYtoZ?: boolean, tryDownload?: boolean) {
             if (shape !== undefined) { this.shape = shape; }
             if (fileName !== undefined) { this.fileName = fileName; }
             if (adjustYtoZ !== undefined) { this.adjustYtoZ = adjustYtoZ; }
+            if (tryDownload !== undefined) { this.tryDownload = tryDownload; }
         }
         /**
          * Shape to save
@@ -4122,13 +4123,20 @@ export namespace OCCT {
          * @default false
          */
         adjustYtoZ = false;
+        /**
+         * Will attempt to downlaod the file if that is possible
+         * @default true
+         */
+        tryDownload? = true;
     }
     export class SaveStlDto<T> {
-        constructor(shape?: T, fileName?: string, precision?: number, adjustYtoZ?: boolean) {
+        constructor(shape?: T, fileName?: string, precision?: number, adjustYtoZ?: boolean, tryDownload?: boolean, binary?: boolean) {
             if (shape !== undefined) { this.shape = shape; }
             if (fileName !== undefined) { this.fileName = fileName; }
             if (precision !== undefined) { this.precision = precision; }
             if (adjustYtoZ !== undefined) { this.adjustYtoZ = adjustYtoZ; }
+            if (tryDownload !== undefined) { this.tryDownload = tryDownload; }
+            if (binary !== undefined) { this.binary = binary; }
         }
         /**
          * Shape to save
@@ -4150,6 +4158,16 @@ export namespace OCCT {
          * @default false
          */
         adjustYtoZ = false;
+        /**
+         * Try download the file if that is possible
+         * @default true
+         */
+        tryDownload? = true;
+        /**
+         * Generate binary STL file
+         * @default true
+         */
+        binary? = true;
     }
     export class ImportStepIgesFromTextDto {
         constructor(text?: string, fileType?: fileTypeEnum, adjustZtoY?: boolean) {

--- a/lib/api/inputs/occ-inputs.ts
+++ b/lib/api/inputs/occ-inputs.ts
@@ -2309,11 +2309,13 @@ export namespace OCCT {
         tolerance = 1e-7;
     }
     export class ZigZagBetweenTwoWiresDto<T> {
-        constructor(wire1?: T, wire2?: T, nrZigZags?: number, inverse?: boolean) {
+        constructor(wire1?: T, wire2?: T, nrZigZags?: number, inverse?: boolean, divideByEqualDistance?: boolean, zigZagsPerEdge?: boolean) {
             if (wire1 !== undefined) { this.wire1 = wire1; }
             if (wire2 !== undefined) { this.wire2 = wire2; }
             if (nrZigZags !== undefined) { this.nrZigZags = nrZigZags; }
             if (inverse !== undefined) { this.inverse = inverse; }
+            if (divideByEqualDistance !== undefined) { this.divideByEqualDistance = divideByEqualDistance; }
+            if (zigZagsPerEdge !== undefined) { this.zigZagsPerEdge = zigZagsPerEdge; }
         }
         /**
          * The first wire for zig zag
@@ -2338,6 +2340,17 @@ export namespace OCCT {
          * @default false
          */
         inverse: boolean;
+        /**
+         * If true, the zig zags will be spaced equally on each edge. By default we follow parametric subdivision of the edges, which is not always equal to distance based subdivisions.
+         * @default false
+         */
+        divideByEqualDistance = false;
+
+        /**
+         * By default the number of zig zags is applied to each edge. If this is set to false, the number of zig zags will be applied to the whole wire. This could then skip some corners where edges meet.
+         * @default true
+         */
+        zigZagsPerEdge = true;
     }
     export class InterpolationDto {
         constructor(points?: Base.Point3[], periodic?: boolean, tolerance?: number) {

--- a/lib/services/base/faces.service.ts
+++ b/lib/services/base/faces.service.ts
@@ -638,7 +638,6 @@ export class FacesService {
             gpPnt.delete();
             return pt;
         });
-        surface.delete();
         return pts;
     }
 

--- a/lib/services/base/wires.service.ts
+++ b/lib/services/base/wires.service.ts
@@ -510,14 +510,31 @@ export class WiresService {
     createZigZagBetweenTwoWires(inputs: Inputs.OCCT.ZigZagBetweenTwoWiresDto<TopoDS_Wire>) {
         const wire1 = inputs.wire1;
         const wire2 = inputs.wire2;
-        const edges1 = this.edgesService.getEdgesAlongWire({ shape: wire1 });
-        const edges2 = this.edgesService.getEdgesAlongWire({ shape: wire2 });
 
-        const ptsEdges1 = edges1.map(e => this.edgesService.divideEdgeByParamsToPoints({ shape: e, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false }));
-        const ptsEdges2 = edges2.map(e => this.edgesService.divideEdgeByParamsToPoints({ shape: e, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false }));
+        let points1 = [];
+        let points2 = [];
 
-        const wires = ptsEdges1.map((pts1, index) => {
-            const pts2 = ptsEdges2[index];
+        if (inputs.zigZagsPerEdge) {
+            const edges1 = this.edgesService.getEdgesAlongWire({ shape: wire1 });
+            const edges2 = this.edgesService.getEdgesAlongWire({ shape: wire2 });
+            if (inputs.divideByEqualDistance) {
+                points1 = edges1.map(e => this.edgesService.divideEdgeByEqualDistanceToPoints({ shape: e, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false }));
+                points2 = edges2.map(e => this.edgesService.divideEdgeByEqualDistanceToPoints({ shape: e, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false }));
+            } else {
+                points1 = edges1.map(e => this.edgesService.divideEdgeByParamsToPoints({ shape: e, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false }));
+                points2 = edges2.map(e => this.edgesService.divideEdgeByParamsToPoints({ shape: e, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false }));
+            }
+        } else {
+            if (inputs.divideByEqualDistance) {
+                points1 = [this.divideWireByEqualDistanceToPoints({ shape: wire1, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false })];
+                points2 = [this.divideWireByEqualDistanceToPoints({ shape: wire2, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false })];
+            } else {
+                points1 = [this.divideWireByParamsToPoints({ shape: wire1, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false })];
+                points2 = [this.divideWireByParamsToPoints({ shape: wire2, nrOfDivisions: inputs.nrZigZags * 2, removeEndPoint: false, removeStartPoint: false })];
+            }
+        }
+        const wires = points1.map((pts1, index) => {
+            const pts2 = points2[index];
 
             const ptsInZigZagOrder = [];
             for (let i = 0; i < pts1.length; i++) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.15.8",
+    "version": "0.15.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/occt",
-            "version": "0.15.8",
+            "version": "0.15.9",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.15.9",
+    "version": "0.15.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bitbybit-dev/occt",
-            "version": "0.15.9",
+            "version": "0.15.10",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.15.8",
+    "version": "0.15.9",
     "description": "Bit By Bit Developers CAD algorithms using OpenCascade Technology kernel. Run in Node and in Browser.",
     "main": "index.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bitbybit-dev/occt",
-    "version": "0.15.9",
+    "version": "0.15.10",
     "description": "Bit By Bit Developers CAD algorithms using OpenCascade Technology kernel. Run in Node and in Browser.",
     "main": "index.js",
     "repository": {

--- a/tsconfig.nodenext.json
+++ b/tsconfig.nodenext.json
@@ -1,0 +1,26 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+    "compileOnSave": false,
+    "exclude": [
+        "lib/workers/occ/services/advanced/**/*",
+        "./**/*.test.ts"
+    ],
+    "compilerOptions": {
+        "outDir": "./dist-n",
+        "baseUrl": "./",
+        "sourceMap": false,
+        "declaration": true,
+        "downlevelIteration": true,
+        "experimentalDecorators": true,
+        "moduleResolution": "node",
+        "skipLibCheck": true,
+        "target": "es2015",
+        "module": "NodeNext",
+        "allowJs": true,
+        "emitDeclarationOnly": false,
+        "lib": [
+            "es2020",
+            "dom"
+        ],
+    }
+}


### PR DESCRIPTION
**bitbybit.occt.shapes.wire.createZigZagBetweenTwoWires** - wires can now be subdivided along all the edges by a given number. It can also use divide by equal distance approach instead of using curve parameters.
**bitbybit.occt.shapeToMesh** - normalized to accept inputs
